### PR TITLE
Remove individual IDs in separate files

### DIFF
--- a/src/main/java/com/github/donotspampls/bolbbot/Constants.java
+++ b/src/main/java/com/github/donotspampls/bolbbot/Constants.java
@@ -3,16 +3,16 @@ package com.github.donotspampls.bolbbot;
 public class Constants {
 
     // Guilds
-    public static final String BOLB_CHAIRS_HUB = "445256982040018964";
-    public static final String BOLB_CHAIRS_1 = "445257017687539713";
-    public static final String BOLB_CHAIRS_2 = "445257039183216661";
-    public static final String BOLB_CHAIRS_3 = "445257054605541389";
-    public static final String BOLB_CHAIRS_4 = "445257077578006539";
-    public static final String BOLB_CHAIRS_5 = "445257303369711626";
-    public static final String BOLB_CHAIRS_6 = "445260596410318858";
+    public static final String BOLB_CHAIRS_HUB = "381863137827094548";
+    public static final String BOLB_CHAIRS_1 = "470862770410225664";
+    public static final String BOLB_CHAIRS_2 = "470862795634769930";
+    public static final String BOLB_CHAIRS_3 = "470862815255592991";
+    public static final String BOLB_CHAIRS_4 = "470862837364031488";
+    public static final String BOLB_CHAIRS_5 = "470862869022375966";
+    public static final String BOLB_CHAIRS_6 = "470862893810712577";
 
     // Channels
-    public static final String GAME_LOGS = "445263102603427840";
+    public static final String GAME_LOGS = "470863481068060673";
 
     // Amount of members in the game servers
     public static int bc1count = 0;
@@ -28,6 +28,11 @@ public class Constants {
     public static int bc3limit = 10;
     public static int bc4limit = 5;
     public static int bc5limit = 3;
+    public static final int BC1_ORIGINAL = 30;
+    public static final int BC2_ORIGINAL = 15;
+    public static final int BC3_ORIGINAL = 10;
+    public static final int BC4_ORIGINAL = 5;
+    public static final int BC5_ORIGINAL = 3;
 
     // Guild Channels
     public static final String BC1_INFO = "info";
@@ -38,5 +43,16 @@ public class Constants {
     public static final String BC4_CHANNEL = "do-you-like-nitro";
     public static final String BC5_CHANNEL = "this-is-not-stressful";
     public static final String BC6_CHANNEL = "no-free-nitro-here";
+    
+    // Hub Roles
+    public static final String BCH_WATCHERS = "470865409185284108";
+    public static final String BCH_CLEANERS = "470865451316936704";
+    public static final String BCH_BOLBS = "470865493486469123";
+    public static final String BC1 = "470867774051188736";
+    public static final String BC2 = "470867772029796353";
+    public static final String BC3 = "470867769945227264";
+    public static final String BC4 = "470867767419994153";
+    public static final String BC5 = "470867764844953600";
+    public static final String BC6 = "470867757278429184";
 
 }

--- a/src/main/java/com/github/donotspampls/bolbbot/Constants.java
+++ b/src/main/java/com/github/donotspampls/bolbbot/Constants.java
@@ -36,8 +36,10 @@ public class Constants {
 
     // Guild Channels
     public static final String BC1_INFO = "info";
+    public static final String BC1_INFO_ID = "453889454814265347";
     public static final String BC1_CHANNEL = "spam";
     public static final String BC2_INFO = "info";
+    public static final String BC2_INFO_ID = "453889514381770754";
     public static final String BC2_CHANNEL = "spam";
     public static final String BC3_CHANNEL = "colon-bolbchair-colon";
     public static final String BC4_CHANNEL = "do-you-like-nitro";

--- a/src/main/java/com/github/donotspampls/bolbbot/Constants.java
+++ b/src/main/java/com/github/donotspampls/bolbbot/Constants.java
@@ -3,16 +3,16 @@ package com.github.donotspampls.bolbbot;
 public class Constants {
 
     // Guilds
-    public static final String BOLB_CHAIRS_HUB = "381863137827094548";
-    public static final String BOLB_CHAIRS_1 = "470862770410225664";
-    public static final String BOLB_CHAIRS_2 = "470862795634769930";
-    public static final String BOLB_CHAIRS_3 = "470862815255592991";
-    public static final String BOLB_CHAIRS_4 = "470862837364031488";
-    public static final String BOLB_CHAIRS_5 = "470862869022375966";
-    public static final String BOLB_CHAIRS_6 = "470862893810712577";
+    public static final String BOLB_CHAIRS_HUB = "445256982040018964";
+    public static final String BOLB_CHAIRS_1 = "445257017687539713";
+    public static final String BOLB_CHAIRS_2 = "445257039183216661";
+    public static final String BOLB_CHAIRS_3 = "445257054605541389";
+    public static final String BOLB_CHAIRS_4 = "445257077578006539";
+    public static final String BOLB_CHAIRS_5 = "445257303369711626";
+    public static final String BOLB_CHAIRS_6 = "445260596410318858";
 
     // Channels
-    public static final String GAME_LOGS = "470863481068060673";
+    public static final String GAME_LOGS = "445263102603427840";
 
     // Amount of members in the game servers
     public static int bc1count = 0;
@@ -45,14 +45,14 @@ public class Constants {
     public static final String BC6_CHANNEL = "no-free-nitro-here";
     
     // Hub Roles
-    public static final String BCH_WATCHERS = "470865409185284108";
-    public static final String BCH_CLEANERS = "470865451316936704";
-    public static final String BCH_BOLBS = "470865493486469123";
-    public static final String BC1 = "470867774051188736";
-    public static final String BC2 = "470867772029796353";
-    public static final String BC3 = "470867769945227264";
-    public static final String BC4 = "470867767419994153";
-    public static final String BC5 = "470867764844953600";
-    public static final String BC6 = "470867757278429184";
+    public static final String BCH_WATCHERS = "445258332391997440";
+    public static final String BCH_CLEANERS = "445258337781547030";
+    public static final String BCH_BOLBS = "445257662662180898";
+    public static final String BC1 = "445326005020655636";
+    public static final String BC2 = "445326003771015180";
+    public static final String BC3 = "445326002944737282";
+    public static final String BC4 = "445326002563055616";
+    public static final String BC5 = "445326001606623232";
+    public static final String BC6 = "445326000167976962";
 
 }

--- a/src/main/java/com/github/donotspampls/bolbbot/Main.java
+++ b/src/main/java/com/github/donotspampls/bolbbot/Main.java
@@ -20,7 +20,7 @@ public class Main {
 
         // Logging in
         DiscordApi api = new DiscordApiBuilder().setToken(args[0]).login().join();
-        api.updateActivity("the waiting song", ActivityType.LISTENING);
+        api.updateActivity("lobby music", ActivityType.LISTENING);
         logger.info("Logged in to Discord account: " + api.getYourself().getDiscriminatedName());
 
         // Create command handler

--- a/src/main/java/com/github/donotspampls/bolbbot/commands/PurgeCommand.java
+++ b/src/main/java/com/github/donotspampls/bolbbot/commands/PurgeCommand.java
@@ -54,7 +54,7 @@ public class PurgeCommand implements CommandExecutor {
             bc6.createTextChannelBuilder().setName(BC6_CHANNEL).create();
             
             // Set playing status
-            api.updateActivity("the waiting song", ActivityType.LISTENING);
+            api.updateActivity("lobby music", ActivityType.LISTENING);
 
             // Kick all members without a role
             bc1.getMembers().stream().filter(member -> member.getRoles(bch).stream().noneMatch(r -> r.equals(bchwatchers) || r.equals(bchcleaners) || r.equals(bchbolbs))).forEach(bc1::kickUser);

--- a/src/main/java/com/github/donotspampls/bolbbot/commands/PurgeCommand.java
+++ b/src/main/java/com/github/donotspampls/bolbbot/commands/PurgeCommand.java
@@ -30,9 +30,9 @@ public class PurgeCommand implements CommandExecutor {
             Server bc6 = api.getServerById(BOLB_CHAIRS_6).get();
 
             // Get roles from the hub
-            Role bchwatchers = bch.getRoleById("445258332391997440").get();
-            Role bchcleaners = bch.getRoleById("445258337781547030").get();
-            Role bchbolbs = bch.getRoleById("445257662662180898").get();
+            Role bchwatchers = bch.getRoleById(BCH_WATCHERS).get();
+            Role bchcleaners = bch.getRoleById(BCH_CLEANERS).get();
+            Role bchbolbs = bch.getRoleById(BCH_BOLBS).get();
 
             // Get all channels and prune them
             bc1.getChannelsByName(BC1_CHANNEL).get(0).delete();
@@ -65,16 +65,17 @@ public class PurgeCommand implements CommandExecutor {
             bc6.getMembers().stream().filter(member -> member.getRoles(bch).stream().noneMatch(r -> r.equals(bchwatchers) || r.equals(bchcleaners) || r.equals(bchbolbs))).forEach(bc6::kickUser);
 
             // Reset limit
-            bc1limit = 30;
-            bc2limit = 15;
-            bc3limit = 10;
-            bc4limit = 5;
-            bc5limit = 3;
+            bc1limit = BC1_ORIGINAL;
+            bc2limit = BC2_ORIGINAL;
+            bc3limit = BC3_ORIGINAL;
+            bc4limit = BC4_ORIGINAL;
+            bc5limit = BC5_ORIGINAL;
             
             // Set welcome message channels (delayed by 5 seconds to fix some issues)
             TimeUnit.SECONDS.sleep(5);
             setMembers(api);
 
+            message.removeAllReactions();
             message.addReaction("\uD83D\uDC4D");
         } else message.delete();
     }

--- a/src/main/java/com/github/donotspampls/bolbbot/listeners/InviteListener.java
+++ b/src/main/java/com/github/donotspampls/bolbbot/listeners/InviteListener.java
@@ -1,5 +1,6 @@
 package com.github.donotspampls.bolbbot.listeners;
 
+import static com.github.donotspampls.bolbbot.Constants.BOLB_CHAIRS_HUB;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.server.Server;
@@ -16,7 +17,7 @@ public class InviteListener implements MessageCreateListener {
         Message msg = ev.getMessage();
         TextChannel channel = ev.getChannel();
 
-        if (server.getName().equals("Bolb Chairs Hub")) {
+        if (server.getIdAsString().equals(BOLB_CHAIRS_HUB)) {
             if (!msg.getAuthor().canCreateInstantInviteToTextChannel()) {
                 if (msg.getContent().contains("discord.gg") | ev.getMessage().getContent().startsWith("https://discordapp.com/invite")) {
                     msg.delete();

--- a/src/main/java/com/github/donotspampls/bolbbot/listeners/ServerJoinListener.java
+++ b/src/main/java/com/github/donotspampls/bolbbot/listeners/ServerJoinListener.java
@@ -24,7 +24,7 @@ public class ServerJoinListener implements ServerMemberJoinListener {
     @Override
     public void onServerMemberJoin(ServerMemberJoinEvent ev) {
         // Get related server names, users and servers
-        String name = ev.getServer().getName();
+        String name = ev.getServer().getIdAsString();
         User user = ev.getUser();
         Server server = ev.getServer();
 
@@ -35,36 +35,36 @@ public class ServerJoinListener implements ServerMemberJoinListener {
         Server bc4srv = api.getServerById(BOLB_CHAIRS_4).get();
         Server bc5srv = api.getServerById(BOLB_CHAIRS_5).get();
         Server bc6srv = api.getServerById(BOLB_CHAIRS_6).get();
-        Role bchwatchers = bchub.getRoleById("445258332391997440").get();
-        Role bchcleaners = bchub.getRoleById("445258337781547030").get();
-        Role bchbolbs = bchub.getRoleById("445257662662180898").get();
+        Role bchwatchers = bchub.getRoleById(BCH_WATCHERS).get();
+        Role bchcleaners = bchub.getRoleById(BCH_CLEANERS).get();
+        Role bchbolbs = bchub.getRoleById(BCH_BOLBS).get();
         
         // Send a join message if a user has joined the server.
         if (user.getRoles(bchub).stream().anyMatch(r -> r.equals(bchwatchers) || r.equals(bchcleaners) || r.equals(bchbolbs))) return;
         else {
             switch (name) {
-                case "Bolb Chairs #1":
+                case BOLB_CHAIRS_1:
                     bc1count += 1;
                     api.getTextChannelById(Constants.GAME_LOGS).ifPresent(textChannel -> textChannel.sendMessage("\uD83D\uDCE5 **" + user.getDiscriminatedName() + "** `" + user.getIdAsString() + "` is **#" + bc1count + "** to join the **" + server.getName() + "** server!"));
                     if (bc1count == 1) api.updateActivity("a Bolb Chairs round", ActivityType.WATCHING);
                     break;
-                case "Bolb Chairs #2":
+                case BOLB_CHAIRS_2:
                     bc2count += 1;
                     api.getTextChannelById(Constants.GAME_LOGS).ifPresent(textChannel -> textChannel.sendMessage("\uD83D\uDCE5 **" + user.getDiscriminatedName() + "** `" + user.getIdAsString() + "` is **#" + bc2count + "** to join the **" + server.getName() + "** server!"));
                     break;
-                case "Bolb Chairs #3":
+                case BOLB_CHAIRS_3:
                     bc3count += 1;
                     api.getTextChannelById(Constants.GAME_LOGS).ifPresent(textChannel -> textChannel.sendMessage("\uD83D\uDCE5 **" + user.getDiscriminatedName() + "** `" + user.getIdAsString() + "` is **#" + bc3count + "** to join the **" + server.getName() + "** server!"));
                     break;
-                case "Bolb Chairs #4":
+                case BOLB_CHAIRS_4:
                     bc4count += 1;
                     api.getTextChannelById(Constants.GAME_LOGS).ifPresent(textChannel -> textChannel.sendMessage("\uD83D\uDCE5 **" + user.getDiscriminatedName() + "** `" + user.getIdAsString() + "` is **#" + bc4count + "** to join the **" + server.getName() + "** server!"));
                     break;
-                case "Bolb Chairs #5":
+                case BOLB_CHAIRS_5:
                     bc5count += 1;
                     api.getTextChannelById(Constants.GAME_LOGS).ifPresent(textChannel -> textChannel.sendMessage("\uD83D\uDCE5 **" + user.getDiscriminatedName() + "** `" + user.getIdAsString() + "` is **#" + bc5count + "** to join the **" + server.getName() + "** server!"));
                     break;
-                case "Bolb Chairs #6":
+                case BOLB_CHAIRS_6:
                     bc1count = 0;
                     bc2count = 0;
                     bc3count = 0;
@@ -72,32 +72,32 @@ public class ServerJoinListener implements ServerMemberJoinListener {
                     bc5count = 0;
                     bc6count += 1;
                     api.getTextChannelById(Constants.GAME_LOGS).ifPresent(textChannel -> textChannel.sendMessage("\uD83D\uDCE5 **" + user.getDiscriminatedName() + "** `" + user.getIdAsString() + "` is **#" + bc6count + "** to join the **" + server.getName() + "** server!"));
-                    api.updateActivity(user.getName() + "'s victory", ActivityType.WATCHING);
+                    api.updateActivity(user.getName() + "'s victory \uD83C\uDF89", ActivityType.WATCHING);
                     break;
                 default: return;
             }
         }
 
         // Assign roles.
-        if (user.getMutualServers().stream().anyMatch(server1 -> server1.getName().equalsIgnoreCase("Bolb Chairs Hub"))) {
+        if (user.getMutualServers().stream().anyMatch(server1 -> server1.getIdAsString().equals(BOLB_CHAIRS_HUB))) {
             switch (name) {
-                case "Bolb Chairs #1":
-                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById("445326005020655636")).ifPresent(role -> role.getServer().addRoleToUser(user, role));
+                case BOLB_CHAIRS_1:
+                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById(BC1)).ifPresent(role -> role.getServer().addRoleToUser(user, role));
                     break;
-                case "Bolb Chairs #2":
-                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById("445326003771015180")).ifPresent(role -> role.getServer().addRoleToUser(user, role));
+                case BOLB_CHAIRS_2:
+                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById(BC2)).ifPresent(role -> role.getServer().addRoleToUser(user, role));
                     break;
-                case "Bolb Chairs #3":
-                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById("445326002944737282")).ifPresent(role -> role.getServer().addRoleToUser(user, role));
+                case BOLB_CHAIRS_3:
+                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById(BC3)).ifPresent(role -> role.getServer().addRoleToUser(user, role));
                     break;
-                case "Bolb Chairs #4":
-                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById("445326002563055616")).ifPresent(role -> role.getServer().addRoleToUser(user, role));
+                case BOLB_CHAIRS_4:
+                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById(BC4)).ifPresent(role -> role.getServer().addRoleToUser(user, role));
                     break;
-                case "Bolb Chairs #5":
-                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById("445326001606623232")).ifPresent(role -> role.getServer().addRoleToUser(user, role));
+                case BOLB_CHAIRS_5:
+                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById(BC5)).ifPresent(role -> role.getServer().addRoleToUser(user, role));
                     break;
-                case "Bolb Chairs #6":
-                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById("445326000167976962")).ifPresent(role -> role.getServer().addRoleToUser(user, role));
+                case BOLB_CHAIRS_6:
+                    api.getServerById(BOLB_CHAIRS_HUB).flatMap(bch -> bch.getRoleById(BC6)).ifPresent(role -> role.getServer().addRoleToUser(user, role));
                     break;
                 default:
             }
@@ -106,11 +106,11 @@ public class ServerJoinListener implements ServerMemberJoinListener {
         // Check if a server is full
         if (server.getIdAsString().equals(BOLB_CHAIRS_1) && bc1count == bc1limit) {
             bc1srv.getInvites().join().forEach(Invite::delete);
-            api.getTextChannelById("453889454814265347").ifPresent(textChannel -> textChannel.sendMessage("@everyone This server is now full! Get ready for the next invite \uD83D\uDC40"));
+            bc1srv.getTextChannelsByName(BC1_INFO).get(0).sendMessage("@everyone This server is now full! Get ready for the next invite \uD83D\uDC40");
         }
         if (server.getIdAsString().equals(BOLB_CHAIRS_2) && bc2count == bc2limit) {
             bc2srv.getInvites().join().forEach(Invite::delete);
-            api.getTextChannelById("453889514381770754").ifPresent(textChannel -> textChannel.sendMessage("@everyone This server is now full! Get ready for the next invite \uD83D\uDC40"));
+            bc2srv.getTextChannelsByName(BC2_INFO).get(0).sendMessage("@everyone This server is now full! Get ready for the next invite \uD83D\uDC40");
         }
         if (server.getIdAsString().equals(BOLB_CHAIRS_3) && bc3count == bc3limit) {
             bc3srv.getInvites().join().forEach(Invite::delete);

--- a/src/main/java/com/github/donotspampls/bolbbot/listeners/ServerJoinListener.java
+++ b/src/main/java/com/github/donotspampls/bolbbot/listeners/ServerJoinListener.java
@@ -106,11 +106,11 @@ public class ServerJoinListener implements ServerMemberJoinListener {
         // Check if a server is full
         if (server.getIdAsString().equals(BOLB_CHAIRS_1) && bc1count == bc1limit) {
             bc1srv.getInvites().join().forEach(Invite::delete);
-            bc1srv.getTextChannelsByName(BC1_INFO).get(0).sendMessage("@everyone This server is now full! Get ready for the next invite \uD83D\uDC40");
+            api.getTextChannelById(BC1_INFO_ID).ifPresent(textChannel -> textChannel.sendMessage("@everyone This server is now full! Get ready for the next invite \uD83D\uDC40"));
         }
         if (server.getIdAsString().equals(BOLB_CHAIRS_2) && bc2count == bc2limit) {
             bc2srv.getInvites().join().forEach(Invite::delete);
-            bc2srv.getTextChannelsByName(BC2_INFO).get(0).sendMessage("@everyone This server is now full! Get ready for the next invite \uD83D\uDC40");
+            api.getTextChannelById(BC2_INFO_ID).ifPresent(textChannel -> textChannel.sendMessage("@everyone This server is now full! Get ready for the next invite \uD83D\uDC40"));
         }
         if (server.getIdAsString().equals(BOLB_CHAIRS_3) && bc3count == bc3limit) {
             bc3srv.getInvites().join().forEach(Invite::delete);

--- a/src/main/java/com/github/donotspampls/bolbbot/listeners/ServerLeaveListener.java
+++ b/src/main/java/com/github/donotspampls/bolbbot/listeners/ServerLeaveListener.java
@@ -9,21 +9,21 @@ public class ServerLeaveListener implements ServerMemberLeaveListener {
 
     @Override
     public void onServerMemberLeave(ServerMemberLeaveEvent ev) {
-        String name = ev.getServer().getName();
+        String name = ev.getServer().getIdAsString();
         switch (name) {
-            case "Bolb Chairs #1":
+            case BOLB_CHAIRS_1:
                 bc1count -= 1;
                 break;
-            case "Bolb Chairs #2":
+            case BOLB_CHAIRS_2:
                 bc2count -= 1;
                 break;
-            case "Bolb Chairs #3":
+            case BOLB_CHAIRS_3:
                 bc3count -= 1;
                 break;
-            case "Bolb Chairs #4":
+            case BOLB_CHAIRS_4:
                 bc4count -= 1;
                 break;
-            case "Bolb Chairs #5":
+            case BOLB_CHAIRS_5:
                 bc5count -= 1;
                 break;
         }


### PR DESCRIPTION
- Removed all IDs that were repeated from Constants, replaced them with actual value from Constants instead
- Should make it a lot simpler for server owners who want to host this bot on their own (only need to modify Constants)
- Idle playing status changed
- Re-add remove all reactions for ,purge
- Standardised retrieving text channels by names for BC1 and BC2 in ServerJoinListener
- All (idk if I missed out any) switches should use IDs from Constants now
- **Basically everything should use IDs now so there's not much needed to be changed when there's a change in channel names, etc.**

(please go through the commits to ensure I didn't break anything, I'm doing this late at night so I'm not sure half of what I'm doing is right)